### PR TITLE
TM[1,2] will use octet string as default packet id

### DIFF
--- a/service-01/PUS-1-2.asn1
+++ b/service-01/PUS-1-2.asn1
@@ -24,10 +24,9 @@
 PUS-1-2 DEFINITIONS AUTOMATIC TAGS ::= BEGIN
 EXPORTS ALL;
 IMPORTS
-    VerificationRequest-ID FROM VerificationRequest
     AcceptanceFailureNotice FROM ErrorCodes;
 
-TM-1-2-FailedAcceptanceVerificationReport ::= TM-1-2-FailedAcceptanceVerificationReportGeneric {VerificationRequest-ID, AcceptanceFailureNotice}
+TM-1-2-FailedAcceptanceVerificationReport ::= TM-1-2-FailedAcceptanceVerificationReportGeneric {OCTET STRING(SIZE(4)), AcceptanceFailureNotice}
 
 TM-1-2-FailedAcceptanceVerificationReportGeneric {Request-ID-Type, AcceptanceFailureNotice-Type} ::= SEQUENCE
 {

--- a/service-01/meta.json
+++ b/service-01/meta.json
@@ -42,16 +42,9 @@
           "name": "Reporting failed acceptance",
           "asn1Files": [
             "PUS-1-2.asn1",
-            "VerificationRequest.asn1",
             "ErrorCodes.asn1"
           ],
-          "requires": [
-            {
-              "module": "CCSDS",
-              "submodule": "CCSDS Packets",
-              "element": "TC Packet"
-            }
-          ]
+          "requires": []
         }
       ]
     },


### PR DESCRIPTION
it will allow to include any incomming data as packet id, even incorrect